### PR TITLE
Remove target=blank in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ PHP OpenAPI Schema library
 
 ## Docs
 
-Docs sited hosted on [github pages](https://adamkirk.github.io/php-openapi-schema/){target=blank}
+Docs sited hosted on [github pages](https://adamkirk.github.io/php-openapi-schema/)


### PR DESCRIPTION
Thought this was a thing in github markdown; aparrently not