### PR TITLE
Modifications while integrating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "scripts": {
         "test": "./vendor/bin/phpunit",
         "csfix": "PHP_CS_FIXER_IGNORE_ENV=true ./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config .php-cs-fixer.php src tests",
-        "stan": "./vendor/bin/phpstan analyse -c phpstan.neon src tests",
+        "stan": "./vendor/bin/phpstan analyse -c phpstan.neon",
         "csfix-dry-run": "PHP_CS_FIXER_IGNORE_ENV=true ./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config .php-cs-fixer.php --dry-run src tests",
         "lint": [
             "@csfix-dry-run",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,3 @@ parameters:
 	level: 10
 	paths:
 		- src
-		- tests

--- a/src/Components/Components.php
+++ b/src/Components/Components.php
@@ -41,7 +41,6 @@ class Components implements Marshallable
 
 	public function __construct()
 	{
-
 		$this->parameters = new Parameters();
 		$this->responses = new Responses();
 		$this->schemas = new Schemas();

--- a/src/Components/Link.php
+++ b/src/Components/Link.php
@@ -15,17 +15,27 @@ class Link implements Marshallable
 	use ConvertsSelfToMarshallable;
 	use HasCustomAttributes;
 
-	protected ?string $description;
-	protected ?string $operationRef;
-	protected ?string $operationId;
-	protected mixed $requestBody;
-	protected Server $body;
+	protected ?string $description = null;
+	protected ?string $operationRef = null;
+	protected ?string $operationId = null;
+	protected mixed $requestBody = null;
+	protected ?Server $server = null;
 	protected StringDictionary $parameters;
+
+	public function __construct()
+	{
+		$this->parameters = new StringDictionary();
+	}
 
 	public function setDescription(?string $description): self
 	{
 		$this->description = $description;
 		return $this;
+	}
+
+	public function getDescription(): ?string
+	{
+		return $this->description;
 	}
 
 	public function setOperationRef(?string $operationRef): self
@@ -34,10 +44,20 @@ class Link implements Marshallable
 		return $this;
 	}
 
+	public function getOperationRef(): ?string
+	{
+		return $this->operationRef;
+	}
+
 	public function setOperationId(?string $operationId): self
 	{
 		$this->operationId = $operationId;
 		return $this;
+	}
+
+	public function getOperationId(): ?string
+	{
+		return $this->operationId;
 	}
 
 	public function setRequestBody(mixed $requestBody): self
@@ -46,9 +66,25 @@ class Link implements Marshallable
 		return $this;
 	}
 
+	public function getRequestBody(): mixed
+	{
+		return $this->requestBody;
+	}
+
 	public function setServer(Server $server): self
 	{
-		$this->body = $server;
+		$this->server = $server;
+		return $this;
+	}
+
+	public function getServer(): ?Server
+	{
+		return $this->server;
+	}
+
+	public function setParameters(StringDictionary $parameters): self
+	{
+		$this->parameters = $parameters;
 		return $this;
 	}
 
@@ -58,4 +94,8 @@ class Link implements Marshallable
 		return $this;
 	}
 
+	public function getParameters(): StringDictionary
+	{
+		return $this->parameters;
+	}
 }

--- a/src/Document.php
+++ b/src/Document.php
@@ -59,6 +59,11 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function getInfo(): Info
+	{
+		return $this->info;
+	}
+
 	public function setJsonSchemaDialect(?string $jsonSchemaDialect): self
 	{
 		$this->jsonSchemaDialect = $jsonSchemaDialect;

--- a/src/Document.php
+++ b/src/Document.php
@@ -26,16 +26,17 @@ class Document implements Marshallable
 	use ConvertsSelfToMarshallable;
 	use HasCustomAttributes;
 
-	protected ?string $openapi;
-	protected Info $info;
-	protected ?string $jsonSchemaDialect;
+	protected ?string $openapi = null;
+	protected ?Info $info = null;
+	protected ?string $jsonSchemaDialect = null;
+	protected ?ExternalDocumentation $externalDocs = null;
+
 	protected Servers $servers;
 	protected PathItems $paths;
 	protected Components $components;
 	protected PathItems $webhooks;
 	protected SecurityRequirements $security;
 	protected Tags $tags;
-	protected ?ExternalDocumentation $externalDocs;
 
 	public function __construct()
 	{
@@ -53,13 +54,18 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function getOpenapi(): ?string
+	{
+		return $this->openapi;
+	}
+
 	public function setInfo(Info $info): self
 	{
 		$this->info = $info;
 		return $this;
 	}
 
-	public function getInfo(): Info
+	public function getInfo(): ?Info
 	{
 		return $this->info;
 	}
@@ -70,10 +76,26 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function getJsonSchemaDialect(): ?string
+	{
+		return $this->jsonSchemaDialect;
+	}
+
 	public function addServers(Server ...$servers): self
 	{
 		$this->servers->add(...$servers);
 		return $this;
+	}
+
+	public function setServers(Servers $servers): self
+	{
+		$this->servers = $servers;
+		return $this;
+	}
+
+	public function getServers(): Servers
+	{
+		return $this->servers;
 	}
 
 	public function addPathItem(string $path, PathItem $item): self
@@ -82,10 +104,26 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function setPathItems(PathItems $pathItems): self
+	{
+		$this->paths = $pathItems;
+		return $this;
+	}
+
+	public function getPathItems(): PathItems
+	{
+		return $this->paths;
+	}
+
 	public function setComponents(Components $components): self
 	{
 		$this->components = $components;
 		return $this;
+	}
+
+	public function getComponents(): Components
+	{
+		return $this->components;
 	}
 
 	public function addWebhook(string $key, PathItem $pathItem): self
@@ -94,10 +132,32 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function setWebhooks(PathItems $webhooks): self
+	{
+		$this->webhooks = $webhooks;
+		return $this;
+	}
+
+	public function getWebhooks(): PathItems
+	{
+		return $this->webhooks;
+	}
+
 	public function addSecurityRequirement(string $key, SecurityRequirement $requirement): self
 	{
 		$this->security->add($key, $requirement);
 		return $this;
+	}
+
+	public function setSecurityRequirements(SecurityRequirements $securityRequirements): self
+	{
+		$this->security = $securityRequirements;
+		return $this;
+	}
+
+	public function getSecurityRequirements(): SecurityRequirements
+	{
+		return $this->security;
 	}
 
 	public function addTags(Tag ...$tags): self
@@ -106,10 +166,26 @@ class Document implements Marshallable
 		return $this;
 	}
 
+	public function setTags(Tags $tags): self
+	{
+		$this->tags = $tags;
+		return $this;
+	}
+
+	public function getTags(): Tags
+	{
+		return $this->tags;
+	}
+
 	public function setExternalDocs(?ExternalDocumentation $externalDocs): self
 	{
 		$this->externalDocs = $externalDocs;
 		return $this;
+	}
+
+	public function getExternalDocs(): ?ExternalDocumentation
+	{
+		return $this->externalDocs;
 	}
 
 	public function toJson(MarshallingContext $ctx): string

--- a/src/Operations/Operation.php
+++ b/src/Operations/Operation.php
@@ -25,7 +25,7 @@ class Operation implements Marshallable
 	protected ?ExternalDocumentation $externalDocs;
 	protected ?string $operationId;
 	protected Parameters $parameters;
-	protected RequestBody $requestBody;
+	protected ?RequestBody $requestBody;
 	protected Security $security;
 	protected Responses $responses;
 	protected Servers $servers;
@@ -80,7 +80,7 @@ class Operation implements Marshallable
 		return $this;
 	}
 
-	public function setRequestBody(RequestBody $requestBody): self
+	public function setRequestBody(?RequestBody $requestBody): self
 	{
 		$this->requestBody = $requestBody;
 		return $this;

--- a/src/Operations/Parameter.php
+++ b/src/Operations/Parameter.php
@@ -48,24 +48,40 @@ class Parameter implements Marshallable
 		return $this;
 	}
 
+	public function setRequired(bool $required): self
+	{
+		$this->required = $required;
+		return $this;
+	}
+
+	/** @deprecated use setRequired */
 	public function isRequired(): self
 	{
 		$this->required = true;
 		return $this;
 	}
 
+	/** @deprecated use setRequired */
 	public function isNotRequired(): self
 	{
 		$this->required = false;
 		return $this;
 	}
 
+	public function setAllowsEmptyValue(bool $allowed): self
+	{
+		$this->allowEmptyValue = $allowed;
+		return $this;
+	}
+
+	/** @deprecated use setAllowsEmptyValue */
 	public function allowsEmptyValue(): self
 	{
 		$this->allowEmptyValue = true;
 		return $this;
 	}
 
+	/** @deprecated use setAllowsEmptyValue */
 	public function doesNotAllowEmptyValue(): self
 	{
 		$this->allowEmptyValue = false;

--- a/src/Operations/PolymorphicSchemas.php
+++ b/src/Operations/PolymorphicSchemas.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenApiSchema\Operations;
+
+use OpenApiSchema\Spec\Collection;
+use OpenApiSchema\Spec\Marshallable;
+
+/**
+ * @extends Collection<Schema>
+ */
+class PolymorphicSchemas extends Collection implements Marshallable
+{
+	protected static function isType(mixed $value): bool
+	{
+		return $value instanceof Schema;
+	}
+}

--- a/src/Operations/RequestBody.php
+++ b/src/Operations/RequestBody.php
@@ -33,12 +33,20 @@ class RequestBody implements Marshallable
 		return $this;
 	}
 
+	public function setRequired(bool $required): self
+	{
+		$this->required = $required;
+		return $this;
+	}
+
+	/** @deprecated use setRequired */
 	public function isRequired(): self
 	{
 		$this->required = true;
 		return $this;
 	}
 
+	/** @deprecated use setRequired */
 	public function isNotRequired(): self
 	{
 		$this->required = false;

--- a/src/Operations/Response.php
+++ b/src/Operations/Response.php
@@ -14,7 +14,7 @@ class Response implements Marshallable
 	use ConvertsSelfToMarshallable;
 	use HasCustomAttributes;
 
-	protected string $description;
+	protected string $description = '';
 	protected Headers $headers;
 	protected Content $content;
 

--- a/src/Operations/Schema.php
+++ b/src/Operations/Schema.php
@@ -87,7 +87,7 @@ class Schema implements Marshallable
 		return $this;
 	}
 
-	public function setDescription(string $description): self
+	public function setDescription(?string $description): self
 	{
 		$this->description = $description;
 		return $this;

--- a/src/Operations/Schema.php
+++ b/src/Operations/Schema.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OpenApiSchema\Operations;
 
-use OpenApiSchema\Spec\HasCustomAttributes;
 use OpenApiSchema\Spec\Marshallable;
+use OpenApiSchema\Spec\HasCustomAttributes;
 use OpenApiSchema\Spec\ConvertsSelfToMarshallable;
 
 class Schema implements Marshallable
@@ -15,7 +15,7 @@ class Schema implements Marshallable
 
 	protected ?string $ref;
 
-	protected ?string $description;
+	protected ?string $description = null;
 
 	/** @var string[] $required */
 	protected array $required;
@@ -31,9 +31,15 @@ class Schema implements Marshallable
 	/** @var string[] $enum */
 	protected array $enum;
 
+	protected ?bool $nullable;
+
 	protected ?Schema $items;
 
 	protected Schemas $properties;
+
+	protected PolymorphicSchemas $oneOf;
+	protected PolymorphicSchemas $anyOf;
+	protected PolymorphicSchemas $allOf;
 
 	// Not sure if there is a strict schema for this, can be all sorts...
 	protected mixed $examples;
@@ -43,6 +49,9 @@ class Schema implements Marshallable
 		$this->required = [];
 		$this->enum = [];
 		$this->properties = new Schemas();
+		$this->oneOf = new PolymorphicSchemas();
+		$this->anyOf = new PolymorphicSchemas();
+		$this->allOf = new PolymorphicSchemas();
 	}
 
 	public function setRef(string $ref): self
@@ -60,6 +69,27 @@ class Schema implements Marshallable
 	public function setFormat(string $format): self
 	{
 		$this->format = $format;
+		return $this;
+	}
+
+	public function addOneOfSchemas(Schema ...$schemas): self
+	{
+		$this->oneOf->add(...$schemas);
+
+		return $this;
+	}
+
+	public function addAnyOfSchemas(Schema ...$schemas): self
+	{
+		$this->anyOf->add(...$schemas);
+
+		return $this;
+	}
+
+	public function addAllOfSchemas(Schema ...$schemas): self
+	{
+		$this->allOf->add(...$schemas);
+
 		return $this;
 	}
 
@@ -90,6 +120,12 @@ class Schema implements Marshallable
 	public function setDescription(?string $description): self
 	{
 		$this->description = $description;
+		return $this;
+	}
+
+	public function setNullable(bool $nullable): self
+	{
+		$this->nullable = $nullable;
 		return $this;
 	}
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -11,14 +11,19 @@ class Reference implements Marshallable
 {
 	use ConvertsSelfToMarshallable;
 
-	protected ?string $ref;
-	protected ?string $summary;
-	protected ?string $description;
+	protected ?string $ref = null;
+	protected ?string $summary = null;
+	protected ?string $description = null;
 
-	public function setSummary(string $summary): self
+	public function setSummary(?string $summary): self
 	{
 		$this->summary = $summary;
 		return $this;
+	}
+
+	public function getSummary(): ?string
+	{
+		return $this->summary;
 	}
 
 	public function setDescription(?string $description): self
@@ -27,9 +32,19 @@ class Reference implements Marshallable
 		return $this;
 	}
 
+	public function getDescription(): ?string
+	{
+		return $this->description;
+	}
+
 	public function setRef(?string $ref): self
 	{
 		$this->ref = $ref;
 		return $this;
+	}
+
+	public function getRef(): ?string
+	{
+		return $this->ref;
 	}
 }

--- a/src/Spec/Collection.php
+++ b/src/Spec/Collection.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace OpenApiSchema\Spec;
 
+use Iterator;
 use stdClass;
+use ArrayIterator;
+use IteratorAggregate;
 use InvalidArgumentException;
 
 /**
  * @template T
+ *
+ * @implements IteratorAggregate<int, T>
  */
-abstract class Collection implements Marshallable
+abstract class Collection implements Marshallable, IteratorAggregate
 {
 	/** @var array<int, T> $items */
 	protected array $items;
@@ -45,6 +50,11 @@ abstract class Collection implements Marshallable
 			fn($item) => $item instanceof Marshallable ? $item->toMarshallable($ctx) : $item,
 			$this->items,
 		);
+	}
+
+	public function getIterator(): Iterator
+	{
+		return new ArrayIterator($this->items);
 	}
 
 	abstract protected static function isType(mixed $value): bool;

--- a/src/Spec/Dictionary.php
+++ b/src/Spec/Dictionary.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace OpenApiSchema\Spec;
 
+use Iterator;
 use stdClass;
+use ArrayIterator;
+use IteratorAggregate;
 use InvalidArgumentException;
 
 /**
  * @template T
+ *
+ * @implements IteratorAggregate<string, T>
  */
-abstract class Dictionary implements Marshallable
+abstract class Dictionary implements Marshallable, IteratorAggregate
 {
 	/**
 	 * @var array<string, T> $items
@@ -63,6 +68,11 @@ abstract class Dictionary implements Marshallable
 			fn($item) => $item instanceof Marshallable ? $item->toMarshallable($ctx) : $item,
 			$this->items,
 		);
+	}
+
+	public function getIterator(): Iterator
+	{
+		return new ArrayIterator($this->items);
 	}
 
 	abstract protected static function isType(mixed $value): bool;

--- a/tests/Unit/Components/LinkTest.php
+++ b/tests/Unit/Components/LinkTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Server\Server;
+use OpenApiSchema\Components\Link;
+use OpenApiSchema\Spec\Marshallable;
+use OpenApiSchema\Spec\StringDictionary;
+use OpenApiSchema\Spec\MarshallingContext;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers Link
+ */
+class LinkTest extends TestCase
+{
+	public function test_initialization()
+	{
+		$link = new Link();
+		$this->assertNull($link->getDescription());
+		$this->assertNull($link->getOperationRef());
+		$this->assertNull($link->getOperationId());
+		$this->assertNull($link->getRequestBody());
+		$this->assertNull($link->getServer());
+		$this->assertEquals(new StringDictionary(), $link->getParameters());
+
+		$this->assertInstanceOf(Marshallable::class, $link);
+	}
+
+	public function test_getters_and_setters()
+	{
+		$link = new Link();
+		$link->setDescription('description');
+		$link->setOperationRef('op_ref');
+		$link->setOperationId('op_id');
+		$link->setRequestBody('request_body');
+		/** @var Server|MockObject $server */
+		$server = $this->createMock(Server::class);
+		$link->setServer($server);
+		$link->addParameter('blah', 'meh');
+
+		$this->assertEquals('description', $link->getDescription());
+		$this->assertEquals('op_ref', $link->getOperationRef());
+		$this->assertEquals('op_id', $link->getOperationId());
+		$this->assertEquals('request_body', $link->getRequestBody());
+		$this->assertSame($server, $link->getServer());
+		$this->assertEquals(
+			(new StringDictionary())
+				->add('blah', 'meh'),
+			$link->getParameters(),
+		);
+
+		$newParams = (new StringDictionary())
+			->add('key1', 'val1')
+			->add('key2', 'val2');
+
+		$link->setParameters($newParams);
+
+		$this->assertEquals($newParams, $link->getParameters());
+	}
+
+	public function test_its_marshallable()
+	{
+		$link = new Link();
+		$link->setDescription('description');
+		$link->setOperationRef('op_ref');
+		$link->setOperationId('op_id');
+		$link->setRequestBody('request_body');
+		/** @var Server|MockObject $server */
+		$server = $this->createMock(Server::class);
+		$server->expects($this->once())->method('toMarshallable')->willReturn(['server']);
+		$link->setServer($server);
+		$link->addParameter('blah', 'meh');
+
+		/** @var MarshallingContext|MockObject $ctx */
+		$ctx = $this->createMock(MarshallingContext::class);
+
+		$this->assertEquals([
+			'description' => 'description',
+			'operationRef' => 'op_ref',
+			'operationId' => 'op_id',
+			'requestBody' => 'request_body',
+			'server' => ['server'],
+			'parameters' => [
+				'blah' => 'meh',
+			],
+		], $link->toMarshallable($ctx));
+	}
+}

--- a/tests/Unit/DocumentTest.php
+++ b/tests/Unit/DocumentTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use stdClass;
+use OpenApiSchema\Document;
+use OpenApiSchema\Meta\Tag;
+use OpenApiSchema\Meta\Info;
+use OpenApiSchema\Meta\Tags;
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Server\Server;
+use OpenApiSchema\Server\Servers;
+use OpenApiSchema\Operations\PathItem;
+use OpenApiSchema\Operations\PathItems;
+use OpenApiSchema\Components\Components;
+use OpenApiSchema\Spec\MarshallingContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use OpenApiSchema\Meta\ExternalDocumentation;
+use OpenApiSchema\Security\SecurityRequirement;
+use OpenApiSchema\Security\SecurityRequirements;
+
+/**
+ * @covers Document
+ */
+class DocumentTest extends TestCase
+{
+	public function test_nothing_is_set(): void
+	{
+		/** @var MarshallingContext|MockObject */
+		$ctx = $this->createMock(MarshallingContext::class);
+		$doc = new Document();
+
+		$this->assertEqualsCanonicalizing(
+			json_encode(["components" => new stdClass()], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+			$doc->toJson($ctx),
+		);
+	}
+
+	public function test_getters_and_setters(): void
+	{
+		$doc = new Document();
+
+		// Openapi
+		$this->assertEquals(null, $doc->getOpenapi());
+		$doc->setOpenapi('3.0.0');
+		$this->assertEquals('3.0.0', $doc->getOpenapi());
+
+		// Info
+		$this->assertEquals(null, $doc->getInfo());
+		/** @var Info|MockObject $info */
+		$info = $this->createMock(Info::class);
+		$doc->setInfo($info);
+		$this->assertSame($info, $doc->getInfo());
+
+		// JsonSchemaDialect
+		$this->assertEquals(null, $doc->getJsonSchemaDialect());
+		$doc->setJsonSchemaDialect('blah');
+		$this->assertSame('blah', $doc->getJsonSchemaDialect());
+
+		// Servers
+		$this->assertTrue($doc->getServers()->isEmpty());
+		/** @var Server|MockObject $server1 */
+		$server1 = $this->createMock(Server::class);
+		/** @var Server|MockObject $server2 */
+		$server2 = $this->createMock(Server::class);
+		/** @var Servers|MockObject $servers */
+		$servers = $this->createMock(Servers::class);
+		$doc->addServers($server1, $server2);
+		$this->assertEquals((new Servers())->add($server1, $server2), $doc->getServers());
+		$doc->setServers($servers);
+		$this->assertSame($servers, $doc->getServers());
+
+		// Paths
+		$this->assertTrue($doc->getPathItems()->isEmpty());
+		/** @var PathItem|MockObject $pathItem1 */
+		$pathItem1 = $this->createMock(PathItem::class);
+		/** @var PathItem|MockObject $pathItem2 */
+		$pathItem2 = $this->createMock(PathItem::class);
+		/** @var PathItems|MockObject $pathItems */
+		$pathItems = $this->createMock(PathItems::class);
+		$doc->addPathItem('path_1', $pathItem1);
+		$doc->addPathItem('path_2', $pathItem2);
+		$this->assertEquals(
+			(new PathItems())
+				->add('path_1', $pathItem1)
+				->add('path_2', $pathItem2),
+			$doc->getPathItems(),
+		);
+		$doc->setPathItems($pathItems);
+		$this->assertSame($pathItems, $doc->getPathItems());
+
+		// Components
+		$this->assertInstanceOf(Components::class, $doc->getComponents());
+		/** @var Components|MockObject $components */
+		$components = $this->createMock(Components::class);
+		$this->assertNotSame($components, $doc->getComponents());
+		$doc->setComponents($components);
+		$this->assertSame($components, $doc->getComponents());
+
+		// Webhooks
+		$this->assertTrue($doc->getWebhooks()->isEmpty());
+		/** @var PathItem|MockObject $webhook1 */
+		$webhook1 = $this->createMock(PathItem::class);
+		/** @var PathItem|MockObject $webhook2 */
+		$webhook2 = $this->createMock(PathItem::class);
+		/** @var PathItems|MockObject $webhooks */
+		$webhooks = $this->createMock(PathItems::class);
+		$doc->addWebhook("webhook_1", $webhook1);
+		$doc->addWebhook("webhook_2", $webhook2);
+		$this->assertEquals(
+			(new PathItems())
+				->add('webhook_1', $webhook1)
+				->add('webhook_2', $webhook2),
+			$doc->getWebhooks(),
+		);
+		$doc->setWebhooks($webhooks);
+		$this->assertSame($webhooks, $doc->getWebhooks());
+
+		// Security
+		$this->assertTrue($doc->getSecurityRequirements()->isEmpty());
+		/** @var SecurityRequirement|MockObject $secReq1 */
+		$secReq1 = $this->createMock(SecurityRequirement::class);
+		/** @var SecurityRequirement|MockObject $secReq2 */
+		$secReq2 = $this->createMock(SecurityRequirement::class);
+		/** @var SecurityRequirements|MockObject $secReqs */
+		$secReqs = $this->createMock(SecurityRequirements::class);
+		$doc->addSecurityRequirement('req_1', $secReq1);
+		$doc->addSecurityRequirement('req_2', $secReq2);
+		$this->assertEquals(
+			(new SecurityRequirements())
+				->add('req_1', $secReq1)
+				->add('req_2', $secReq2),
+			$doc->getSecurityRequirements(),
+		);
+
+		$doc->setSecurityRequirements($secReqs);
+		$this->assertSame($secReqs, $doc->getSecurityRequirements());
+
+		// Tags
+		$this->assertTrue($doc->getTags()->isEmpty());
+		/** @var Tag|MockObject $tag1 */
+		$tag1 = $this->createMock(Tag::class);
+		/** @var Tag|MockObject $tag2 */
+		$tag2 = $this->createMock(Tag::class);
+		/** @var Tags|MockObject $tags */
+		$tags = $this->createMock(Tags::class);
+		$doc->addTags($tag1, $tag2);
+		$this->assertEquals(
+			(new Tags())->add($tag1, $tag2),
+			$doc->getTags(),
+		);
+		$doc->setTags($tags);
+		$this->assertSame($tags, $doc->getTags());
+
+		// External docs
+		$this->assertNull($doc->getExternalDocs());
+		/** @var ExternalDocumentation|MockObject $extDoc */
+		$extDoc = $this->createMock(ExternalDocumentation::class);
+		$doc->setExternalDocs($extDoc);
+		$this->assertSame($extDoc, $doc->getExternalDocs());
+		$doc->setExternalDocs(null);
+		$this->assertNull($doc->getExternalDocs());
+	}
+
+	public function test_to_json_when_everything_is_set(): void
+	{
+		/** @var MarshallingContext|MockObject */
+		$ctx = $this->createMock(MarshallingContext::class);
+
+		/** @var Info|MockObject */
+		$info = $this->createMock(Info::class);
+		$info->expects($this->any())->method('toMarshallable')->willReturn([
+			'component' => 'info',
+		]);
+
+		/** @var Server|MockObject */
+		$server1 = $this->createMock(Server::class);
+		$server1->expects($this->any())->method('toMarshallable')->willReturn(['server' => '1']);
+
+		/** @var Server|MockObject */
+		$server2 = $this->createMock(Server::class);
+		$server2->expects($this->any())->method('toMarshallable')->willReturn(['server' => '2']);
+
+		/** @var PathItem|MockObject */
+		$pathItem1 = $this->createMock(PathItem::class);
+		$pathItem1->expects($this->any())->method('toMarshallable')->willReturn(['pathItem' => '1']);
+
+		/** @var PathItem|MockObject */
+		$pathItem2 = $this->createMock(PathItem::class);
+		$pathItem2->expects($this->any())->method('toMarshallable')->willReturn(['pathItem' => '2']);
+
+		/** @var Components|MockObject */
+		$components = $this->createMock(Components::class);
+		$components->expects($this->any())->method('toMarshallable')->willReturn(['component' => 'components']);
+
+
+		/** @var SecurityRequirement|MockObject */
+		$secRequirement1 = $this->createMock(SecurityRequirement::class);
+		$secRequirement1->expects($this->any())->method('toMarshallable')->willReturn(['secreq' => '1']);
+
+		/** @var SecurityRequirement|MockObject */
+		$secRequirement2 = $this->createMock(SecurityRequirement::class);
+		$secRequirement2->expects($this->any())->method('toMarshallable')->willReturn(['secreq' => '2']);
+
+		/** @var Tag|MockObject */
+		$tag1 = $this->createMock(Tag::class);
+		$tag1->expects($this->any())->method('toMarshallable')->willReturn(['tag' => '1']);
+
+		/** @var Tag|MockObject */
+		$tag2 = $this->createMock(Tag::class);
+		$tag2->expects($this->any())->method('toMarshallable')->willReturn(['tag' => '2']);
+
+		/** @var ExternalDocumentation|MockObject */
+		$extDoc = $this->createMock(ExternalDocumentation::class);
+		$extDoc->expects($this->any())->method('toMarshallable')->willReturn(['component' => 'extdoc']);
+
+		/** @var PathItem|MockObject */
+		$webhook1 = $this->createMock(PathItem::class);
+		$webhook1->expects($this->any())->method('toMarshallable')->willReturn(['webhook' => '1']);
+
+		/** @var PathItem|MockObject */
+		$webhook2 = $this->createMock(PathItem::class);
+		$webhook2->expects($this->any())->method('toMarshallable')->willReturn(['webhook' => '2']);
+
+		$doc = new Document();
+		$doc->setOpenapi("3.0.0")
+			->setInfo($info)
+			->setJsonSchemaDialect("some/dialect")
+			->addServers($server1, $server2)
+			->addPathItem('path_1', $pathItem1)
+			->addPathItem('path_2', $pathItem2)
+			->setComponents($components)
+			->addSecurityRequirement('req_1', $secRequirement1)
+			->addSecurityRequirement('req_2', $secRequirement2)
+			->addTags($tag1, $tag2)
+			->setExternalDocs($extDoc)
+			->addWebhook('webhook_1', $webhook1)
+			->addWebhook('webhook_2', $webhook2)
+			->addCustomAttribute('some-custom-key', ['some', 'values'])
+			->addCustomAttribute('other-custom-key', 'some-string');
+
+		$this->assertEquals(
+			json_encode([
+				'openapi' => '3.0.0',
+				'info' => [
+					'component' => 'info',
+				],
+				'jsonSchemaDialect' => 'some/dialect',
+				'externalDocs' => [
+					'component' => 'extdoc',
+				],
+				'servers' => [
+					['server' => '1'],
+					['server' => '2'],
+				],
+				'paths' => [
+					'path_1' => ['pathItem' => '1'],
+					'path_2' => ['pathItem' => '2'],
+				],
+				'components' => [
+					'component' => 'components',
+				],
+				'webhooks' => [
+					'webhook_1' => [
+						'webhook' => '1',
+					],
+					'webhook_2' => [
+						'webhook' => '2',
+					],
+				],
+				'security' => [
+					'req_1' => ['secreq' => '1'],
+					'req_2' => ['secreq' => '2'],
+				],
+				'tags' => [
+					['tag' => '1'],
+					['tag' => '2'],
+				],
+				'some-custom-key' => ['some', 'values'],
+				'other-custom-key' => 'some-string',
+			], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+			$doc->toJson($ctx),
+		);
+	}
+}

--- a/tests/Unit/ReferenceTest.php
+++ b/tests/Unit/ReferenceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use OpenApiSchema\Reference;
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Spec\Marshallable;
+use OpenApiSchema\Spec\MarshallingContext;
+
+/**
+ * @covers Reference
+ */
+class ReferenceTest extends TestCase
+{
+	public function test_initialization()
+	{
+		$ref = new Reference();
+
+		$this->assertNull($ref->getSummary());
+		$this->assertNull($ref->getDescription());
+		$this->assertNull($ref->getRef());
+
+		$this->assertInstanceOf(Marshallable::class, $ref);
+
+	}
+
+	public function test_getters_and_setters()
+	{
+		$ref = new Reference();
+
+		$ref->setSummary('summary');
+		$ref->setDescription('description');
+		$ref->setRef('ref');
+
+		$this->assertEquals('summary', $ref->getSummary());
+		$this->assertEquals('description', $ref->getDescription());
+		$this->assertEquals('ref', $ref->getRef());
+	}
+
+	public function test_its_marshallable()
+	{
+		$ref = new Reference();
+
+		$ref->setSummary('summary');
+		$ref->setDescription('description');
+		$ref->setRef('ref');
+
+		/** @var MockObject|MarshallingContext */
+		$ctx = $this->createMock(MarshallingContext::class);
+
+		$res = $ref->toMarshallable($ctx);
+
+		$this->assertEquals([
+			'description' => 'description',
+			'summary' => 'summary',
+			'$ref' => 'ref',
+		], $res);
+	}
+}

--- a/tests/Unit/Spec/CollectionTest.php
+++ b/tests/Unit/Spec/CollectionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use OpenApiSchema\Spec\Collection;
 use OpenApiSchema\Spec\MarshallingContext;
 use Tests\Unit\Spec\Stubs\StringCollection;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -51,6 +52,7 @@ class CollectionTest extends TestCase
 
 	public function test_to_marshallable(): void
 	{
+		/** @var MarshallingContext|MockObject */
 		$ctx = $this->createMock(MarshallingContext::class);
 		$coll = new StringCollection();
 		$coll->add("some");
@@ -60,5 +62,23 @@ class CollectionTest extends TestCase
 			["some", "strings"],
 			$coll->toMarshallable($ctx),
 		);
+	}
+
+	public function test_can_iterate(): void
+	{
+		$coll = new StringCollection();
+		$coll->add("some", "strings");
+		$coll->add("other");
+
+		$values = [];
+		foreach ($coll as $key => $value) {
+			$values[$key] = $value;
+		}
+
+		$this->assertEquals([
+			0 => 'some',
+			1 => 'strings',
+			2 => 'other',
+		], $values);
 	}
 }

--- a/tests/Unit/Spec/ConvertsSelfToMarshallableTest.php
+++ b/tests/Unit/Spec/ConvertsSelfToMarshallableTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use stdClass;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Spec\Collection;
+use OpenApiSchema\Spec\Dictionary;
+use OpenApiSchema\Spec\MarshallingContext;
+use Tests\Unit\Spec\Stubs\MarshallableBase;
+use PHPUnit\Framework\MockObject\MockObject;
+use OpenApiSchema\Spec\CustomAttributeDictionary;
+use Tests\Unit\Spec\Stubs\MarshallableArrayWhenEmpty;
+use Tests\Unit\Spec\Stubs\MarshallableRetainEmptyArrays;
+use Tests\Unit\Spec\Stubs\MarshallableWithCustomAttributes;
+use Tests\Unit\Spec\Stubs\MarshallableRetainEmptyCollections;
+
+/**
+ * @covers ConvertsSelfToMarshallable
+ */
+class ConvertsSelfToMarshallableTest extends TestCase
+{
+	/**
+	 * @dataProvider scenarios
+	 */
+	public function test_to_marshallable(callable $buildSubject, array|stdClass $expect): void
+	{
+		/** ConvertsSelfToMarshallable $subject */
+		$subject = $buildSubject($this);
+
+		$ctx = $this->createMock(MarshallingContext::class);
+		$output = $subject->toMarshallable($ctx);
+
+		$this->assertEqualsCanonicalizing($expect, $output);
+	}
+
+	public static function scenarios(): Generator
+	{
+		yield 'everything populated' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(false);
+				$collection->expects($test->any())->method('toMarshallable')->willReturn([
+					'my-collection',
+				]);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(false);
+				$dict->expects($test->any())->method('toMarshallable')->willReturn([
+					'my' => 'dict',
+				]);
+
+				return new MarshallableBase(
+					$collection,
+					[
+						'some-array',
+					],
+					$dict,
+					'some-string',
+				);
+			},
+			[
+				'someCollection' => [
+					'my-collection',
+				],
+				'someArray' => [
+					'some-array',
+				],
+				'someDict' => [
+					'my' => 'dict',
+				],
+				'someString' => 'some-string',
+			],
+		];
+
+		yield 'all collections/dictionaries are empty' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableBase(
+					$collection,
+					[],
+					$dict,
+					'some-string',
+				);
+			},
+			[
+				'someString' => 'some-string',
+			],
+		];
+
+		yield 'everything is empty' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableBase(
+					$collection,
+					[],
+					$dict,
+					null,
+				);
+			},
+			new stdClass(),
+		];
+
+		yield 'empty collections are not omitted' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableRetainEmptyCollections(
+					$collection,
+					[],
+					$dict,
+					null,
+				);
+			},
+			[
+				'someCollection' => [],
+			],
+		];
+
+		yield 'empty arrays are not omitted' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableRetainEmptyArrays(
+					$collection,
+					[],
+					$dict,
+					null,
+				);
+			},
+			[
+				'someArray' => [],
+			],
+		];
+
+		yield 'empty dictionaires are not omitted' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableRetainEmptyArrays(
+					$collection,
+					[],
+					$dict,
+					null,
+				);
+			},
+			[
+				'someDict' => [],
+			],
+		];
+
+		yield 'overrides to return array when empty' => [
+			function (self $test) {
+				/** @var Collection|MockObject $collection */
+				$collection = $test->createMock(Collection::class);
+				$collection->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				/** @var Dictionary|MockObject $dict */
+				$dict = $test->createMock(Dictionary::class);
+				$dict->expects($test->any())->method('isEmpty')->willReturn(true);
+
+				return new MarshallableArrayWhenEmpty(
+					$collection,
+					[],
+					$dict,
+					null,
+				);
+			},
+			[],
+		];
+
+		yield 'custom attributes are included' => [
+			function (self $test) {
+				/** @var CustomAttributeDictionary|MockObject $custom */
+				$custom = $test->createMock(CustomAttributeDictionary::class);
+				$custom->expects($test->any())->method('toMarshallable')->willReturn([
+					'custom' => 'attribute',
+				]);
+
+				return new MarshallableWithCustomAttributes(
+					$custom,
+					'some-string',
+				);
+			},
+			[
+				'someString' => 'some-string',
+				'custom' => 'attribute',
+			],
+		];
+
+		yield 'custom attribute overrides class property' => [
+			function (self $test) {
+				/** @var CustomAttributeDictionary|MockObject $custom */
+				$custom = $test->createMock(CustomAttributeDictionary::class);
+				$custom->expects($test->any())->method('toMarshallable')->willReturn([
+					'someString' => 'my-override',
+				]);
+
+				return new MarshallableWithCustomAttributes(
+					$custom,
+					'some-string',
+				);
+			},
+			[
+				'someString' => 'my-override',
+			],
+		];
+
+		yield 'custom attribute with ref prop is prefixed with $' => [
+			function (self $test) {
+				/** @var CustomAttributeDictionary|MockObject $custom */
+				$custom = $test->createMock(CustomAttributeDictionary::class);
+				$custom->expects($test->any())->method('toMarshallable')->willReturn([
+					'ref' => 'blah',
+				]);
+
+				return new MarshallableWithCustomAttributes(
+					$custom,
+					'some-string',
+				);
+			},
+			[
+				'someString' => 'some-string',
+				'$ref' => 'blah',
+			],
+		];
+	}
+}

--- a/tests/Unit/Spec/CustomAttributeDictionaryTest.php
+++ b/tests/Unit/Spec/CustomAttributeDictionaryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use OpenApiSchema\Spec\CustomAttributeDictionary;
+
+/**
+ * @covers CustomAttributeDictionary
+ */
+class CustomAttributeDictionaryTest extends TestCase
+{
+	/**
+	 * @dataProvider invalidTypes
+	 */
+	public function test_allows_any_type(mixed $val): void
+	{
+		$subject = new CustomAttributeDictionary();
+
+		$subject->add("blah", $val);
+		// We just don't wanna throw an exception...
+		$this->expectNotToPerformAssertions();
+	}
+
+	/**
+	 * Could probably do more, but this covers most of it...
+	 */
+	public static function invalidTypes(): Generator
+	{
+		yield "int" => [1234];
+		yield "bool" => [true];
+		yield "array" => [["some", "array"]];
+		yield "object" => [(object) ["someProp" => "object"]];
+		yield "string" => ["blah"];
+	}
+}

--- a/tests/Unit/Spec/HasCustomAttributesTest.php
+++ b/tests/Unit/Spec/HasCustomAttributesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Spec\CustomAttributeDictionary;
+use Tests\Unit\Spec\Stubs\HasCustomAttributesStub;
+
+/**
+ * @covers HasCustomAttributes
+ */
+class HasCustomAttributesTest extends TestCase
+{
+	public function test_when_none_are_set_its_null(): void
+	{
+		$subject = new HasCustomAttributesStub();
+
+		$this->assertNull($subject->getCustomAttributes());
+	}
+
+	public function test_attributes_can_be_added(): void
+	{
+		$subject = new HasCustomAttributesStub();
+
+		$subject->addCustomAttribute("custom", "attribute");
+		$subject->addCustomAttribute("other", "value");
+
+		$this->assertEquals(
+			(new CustomAttributeDictionary())->add("custom", "attribute")->add('other', 'value'),
+			$subject->getCustomAttributes(),
+		);
+	}
+
+}

--- a/tests/Unit/Spec/MarshallingContextTest.php
+++ b/tests/Unit/Spec/MarshallingContextTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Spec\MarshallingContext;
+
+/**
+ * @covers MarshallingContext
+ */
+class MarshallingContextTest extends TestCase
+{
+	public function test_defaults_for_get(): void
+	{
+		$subject = new MarshallingContext();
+
+		$this->assertNull($subject->get('blah'));
+		$this->assertEquals('meh', $subject->get('blah', 'meh'));
+	}
+
+	public function test_setting_values(): void
+	{
+		$subject = new MarshallingContext();
+
+		$this->assertNull($subject->get('blah'));
+		$subject->set('blah', 'meh');
+		$this->assertEquals('meh', $subject->get('blah'));
+
+		$subject->setIfNotExists('blah', 'blah');
+		// Value shouldn't change cause the key is already set
+		$this->assertEquals('meh', $subject->get('blah'));
+
+		$subject->setIfNotExists('newvalue', 1234);
+		$this->assertEquals(1234, $subject->get('newvalue'));
+	}
+}

--- a/tests/Unit/Spec/StringDictionaryTest.php
+++ b/tests/Unit/Spec/StringDictionaryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec;
+
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use OpenApiSchema\Spec\StringDictionary;
+use OpenApiSchema\Spec\MarshallingContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * This actually covers base functionality of the abstract and this specific
+ * implementation. I don't like them being done together, but to test the abstract
+ * I wrote a stub that was identical to StringDictionary anyway, so bit pointless
+ * testing an identical class twice.
+ *
+ * @covers Dictionary
+ * @covers StringDictionary
+ */
+class StringDictionaryTest extends TestCase
+{
+	public function test_is_empty(): void
+	{
+		$dict = new StringDictionary();
+		$this->assertTrue($dict->isEmpty());
+
+		$dict->add("key", "value");
+
+		$this->assertFalse($dict->isEmpty());
+	}
+
+	/**
+	 * @dataProvider invalidTypes
+	 */
+	public function test_adding_invalid_types(mixed $val): void
+	{
+		$this->expectExceptionObject(
+			new InvalidArgumentException('incorrect type for ' . StringDictionary::class),
+		);
+		$dict = new StringDictionary();
+
+		/** @phpstan-ignore argument.type */
+		$dict->add("key", $val);
+	}
+
+	public static function invalidTypes(): Generator
+	{
+		yield "int" => [1234];
+		yield "bool" => [true];
+		yield "array" => [["some", "array"]];
+	}
+
+	public function test_has(): void
+	{
+		$dict = new StringDictionary();
+		$dict->add("key1", "some");
+		$dict->add("key2", "strings");
+
+		$this->assertTrue($dict->has('key1'));
+		$this->assertTrue($dict->has('key2'));
+
+		$this->assertFalse($dict->has('missing'));
+	}
+
+	public function test_get(): void
+	{
+		$dict = new StringDictionary();
+		$dict->add("key1", "some");
+		$dict->add("key2", "strings");
+
+		$this->assertEquals('some', $dict->get('key1'));
+		$this->assertEquals('strings', $dict->get('key2'));
+
+		$this->assertNull($dict->get('missing'));
+		$this->assertEquals('somedefault', $dict->get('missing', 'somedefault'));
+	}
+
+	public function test_to_marshallable(): void
+	{
+		/** @var MarshallingContext|MockObject */
+		$ctx = $this->createMock(MarshallingContext::class);
+		$dict = new StringDictionary();
+		$dict->add("key1", "some");
+		$dict->add("key2", "strings");
+
+		$this->assertEquals(
+			["key1" => "some", "key2" => "strings"],
+			$dict->toMarshallable($ctx),
+		);
+	}
+
+	public function test_can_iterate(): void
+	{
+		$dict = new StringDictionary();
+		$dict->add("key1", "some");
+		$dict->add("key2", "strings");
+
+		$values = [];
+		foreach ($dict as $key => $value) {
+			$values[$key] = $value;
+		}
+
+		$this->assertEquals([
+			'key1' => 'some',
+			'key2' => 'strings',
+		], $values);
+	}
+}

--- a/tests/Unit/Spec/Stubs/HasCustomAttributesStub.php
+++ b/tests/Unit/Spec/Stubs/HasCustomAttributesStub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+use OpenApiSchema\Spec\HasCustomAttributes;
+use OpenApiSchema\Spec\CustomAttributeDictionary;
+
+class HasCustomAttributesStub
+{
+	use HasCustomAttributes;
+
+	/**
+	 * Just return the value so we can verify the behaviour of the trait...
+	 */
+	public function getCustomAttributes(): ?CustomAttributeDictionary
+	{
+		return $this->customAttributes;
+	}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableArrayWhenEmpty.php
+++ b/tests/Unit/Spec/Stubs/MarshallableArrayWhenEmpty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+class MarshallableArrayWhenEmpty extends MarshallableBase
+{
+	protected function useJsonObjectWhenEmpty(): bool
+	{
+		return false;
+	}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableBase.php
+++ b/tests/Unit/Spec/Stubs/MarshallableBase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+use OpenApiSchema\Spec\Collection;
+use OpenApiSchema\Spec\Dictionary;
+use OpenApiSchema\Spec\ConvertsSelfToMarshallable;
+
+class MarshallableBase
+{
+	use ConvertsSelfToMarshallable;
+
+	public function __construct(
+		protected Collection $someCollection,
+		protected array $someArray,
+		protected Dictionary $someDict,
+		protected ?string $someString,
+	) {}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableRetainEmptyArrays.php
+++ b/tests/Unit/Spec/Stubs/MarshallableRetainEmptyArrays.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+class MarshallableRetainEmptyArrays extends MarshallableBase
+{
+	protected function omitEmptyArrays(): bool
+	{
+		return false;
+	}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableRetainEmptyCollections.php
+++ b/tests/Unit/Spec/Stubs/MarshallableRetainEmptyCollections.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+class MarshallableRetainEmptyCollections extends MarshallableBase
+{
+	protected function omitEmptyCollections(): bool
+	{
+		return false;
+	}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableRetainEmptyDictionaries.php
+++ b/tests/Unit/Spec/Stubs/MarshallableRetainEmptyDictionaries.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+class MarshallableRetainEmptyDictionaries extends MarshallableBase
+{
+	protected function omitEmptyDictionaries(): bool
+	{
+		return false;
+	}
+}

--- a/tests/Unit/Spec/Stubs/MarshallableWithCustomAttributes.php
+++ b/tests/Unit/Spec/Stubs/MarshallableWithCustomAttributes.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Spec\Stubs;
+
+use OpenApiSchema\Spec\CustomAttributeDictionary;
+use OpenApiSchema\Spec\ConvertsSelfToMarshallable;
+
+class MarshallableWithCustomAttributes
+{
+	use ConvertsSelfToMarshallable;
+
+	public function __construct(
+		protected CustomAttributeDictionary $customAttributes,
+		protected ?string $someString,
+	) {}
+}


### PR DESCRIPTION
Mostly consisted of the following improvements after trying to integrate the library somewhere:
- remove boolean setters in favour of a setRequired method, it's slightly less expressive but more convenient
- make some setters accept a nullable type where the actual value can be null. This just makes it more convenient on the consumer side as you can pass a value without having to conditionally check it and then call the setter
- make collection and dictionary iterable; again makes it more convenient on the consumer side. Could probably do with do with some more generic functions like map/reduce etc, but i might add those later; for now we can use loops.